### PR TITLE
Use Vite plugin buildEnd hook to copy index.html to 404.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "sideEffects": false,
   "type": "module",
   "scripts": {
-    "build": "remix vite:build && cp build/client/index.html build/client/404.html",
+    "build": "remix vite:build",
     "dev": "remix vite:dev",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "preview": "vite preview",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         if (!args.viteConfig.isProduction) return;
 
         // copy the index.html to 404.html for GH Pages
-        let buildPath = args.viteConfig.build.outDir;
+        const buildPath = args.viteConfig.build.outDir;
         copyFileSync(
           join(buildPath, "index.html"),
           join(buildPath, "404.html"),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import { vitePlugin as remix } from "@remix-run/dev";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { copyFileSync } from "node:fs";
+import { join } from "node:path";
 
 export default defineConfig({
   base: "/remix-gh-pages/",
@@ -8,6 +10,16 @@ export default defineConfig({
     remix({
       ssr: false,
       basename: "/remix-gh-pages/",
+      buildEnd(args) {
+        if (!args.viteConfig.isProduction) return;
+
+        // copy the index.html to 404.html for GH Pages
+        let buildPath = args.viteConfig.build.outDir;
+        copyFileSync(
+          join(buildPath, "index.html"),
+          join(buildPath, "404.html"),
+        );
+      },
     }),
     tsconfigPaths(),
   ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,14 @@ export default defineConfig({
       buildEnd(args) {
         if (!args.viteConfig.isProduction) return;
 
-        // copy the index.html to 404.html for GH Pages
+        // When deploying to GitHub Pages, if you navigate from / to another
+        // route and refresh the tab, it will show the default GH Pages 404
+        // page. This happens because GH Pages is not configured to send all
+        // traffic to the index.html where we can load our client-side JS.
+        // To fix this, we can create a 404.html file that contains the same
+        // content as index.html. This way, when the user refreshes the page,
+        // GH Pages will serve our 404.html and everything will work as
+        //expected.
         const buildPath = args.viteConfig.build.outDir;
         copyFileSync(
           join(buildPath, "index.html"),


### PR DESCRIPTION
This change will use the buildEnd option in the Vite plugin to copy over the index.html to 404.html instead of doing it in the package.json.

While more code, it's not hidden anymore inside a package.json script, it only runs in production and it can be commented to explain the reason why it's needed for anyone using the repo as a base.